### PR TITLE
Add additional API options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm i -S svelte svelte-frappe-charts
 
 Use the chart in your Svelte project with ease:
 
-```jsx
+```svelte
 <script>
   import Chart from 'svelte-frappe-charts';
 
@@ -55,11 +55,115 @@ Use the chart in your Svelte project with ease:
 
 The component API directly matches the [the configuration of `frappe-charts`](https://frappe.io/charts/docs/reference/configuration).
 
+### Updating data
+
+There are two ways to update data in a chart: either in adding and removing individual points, or updating the existing data with an entirely new set of data points.
+
+#### Updating individual data points
+
+##### addDataPoint
+
+Add a data point to the chart, increasing the length of the dataset.
+
+```svelte
+<script>
+  import Chart from 'svelte-frappe-charts';
+
+  let data = {
+    labels: ['Sun', 'Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat'],
+    datasets: [
+      {
+        values: [10, 12, 3, 9, 8, 15, 9]
+      }
+    ]
+  };
+
+  let chartRef;
+
+  function addDataPoint() {
+    chartRef.addDataPoint('Wed', [30], 1);
+  }
+</script>
+
+<Chart data={data} type="line" bind:this={chartRef} />
+
+<button on:click={addDataPoint}>Add data point</button>
+```
+
+[More info on `addDataPoint`.](https://frappe.io/charts/docs/reference/api#adddatapoint)
+
+##### removeDataPoint
+
+Remove a data point from the chart, reducing the length of the dataset.
+
+```svelte
+<script>
+  import Chart from 'svelte-frappe-charts';
+
+  let data = {
+    labels: ['Sun', 'Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat'],
+    datasets: [
+      {
+        values: [10, 12, 3, 9, 8, 15, 9]
+      }
+    ]
+  };
+
+  let chartRef;
+
+  function removeDataPoint() {
+    chartRef.removeDataPoint(3); // Index of the item to remove
+  }
+</script>
+
+<Chart data={data} type="line" bind:this={chartRef} />
+
+<button on:click={removeDataPoint}>Remove data point</button>
+```
+
+[More info on `removeDataPoint`.](https://frappe.io/charts/docs/reference/api#removedatapoint)
+
+#### Updating full data
+
+Update the entire data, including annotations, by passing the entire new data object to update.
+
+```svelte
+<script>
+  import Chart from 'svelte-frappe-charts';
+
+  let data = {
+    labels: ['Sun', 'Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat'],
+    datasets: [
+      {
+        values: [10, 12, 3, 9, 8, 15, 9]
+      }
+    ]
+  };
+
+  let chartRef;
+
+  function updateData() {
+    data = {
+      labels: ['Friday', 'Saturday', 'Sunday'],
+      datasets: [
+        {
+          values: [300, 380, 275]
+        }
+      ]
+    };
+  }
+</script>
+
+<Chart data={data} type="line" bind:this={chartRef} />
+
+<button on:click={updateData}>Update Chart</button>
+```
+
 ### Exporting charts
 
 You can easily export a chart ([see Exporting](https://frappe.io/charts/docs/exporting/images)) as an SVG by storing a reference to the `<Chart />` component, and then calling `exportChart` on it:
 
-```jsx
+```svelte
 <script>
   // ...
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "frappe-charts": "^1.5.2",
-    "svelte": "^3.24.1"
+    "svelte": "^3.25.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",
@@ -19,10 +19,10 @@
     "jest": "^26.4.2",
     "jest-transform-svelte": "^2.1.1",
     "np": "^6.5.0",
-    "rollup": "^2.26.9",
+    "rollup": "^2.26.11",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-svelte": "^6.0.0"
+    "rollup-plugin-svelte": "^6.0.1"
   },
   "peerDependencies": {
     "svelte": "^3.0.0"

--- a/src/components/base.svelte
+++ b/src/components/base.svelte
@@ -23,24 +23,6 @@
   export let valuesOverPoints = 0;
   export let isNavigable = false;
   export let maxSlices = 3;
-  //  Allow the consumer to export the chart
-  export function exportChart() {
-    if (chart) {
-      chart.export();
-    }
-  }
-  //  Allow the consumer to add a data point
-  export function addDataPoint(label, valueFromEachDataset, index) {
-    if (chart) {
-      chart.addDataPoint(label, valueFromEachDataset, index);
-    }
-  }
-  //  Allow the consumer to remove a data point
-  export function removeDataPoint(index) {
-    if (chart) {
-      chart.removeDataPoint(index);
-    }
-  }
 
   /**
    *  COMPONENT
@@ -50,6 +32,30 @@
   //  DOM node for frappe to latch onto
   let chartRef;
 
+  //  Helper HOF for calling a fn only if chart exists
+  function ifChartThen(fn) {
+    return function ifChart(...args) {
+      if (chart) {
+        return fn(...args);
+      }
+    }
+  }
+
+  /**
+   * Methods for updating / exporting the chart
+   */
+  //  Allow the consumer to add a data point
+  export const addDataPoint = ifChartThen((label, valueFromEachDataset, index) => chart.addDataPoint(label, valueFromEachDataset, index));
+
+  //  Allow the consumer to remove a data point
+  export const removeDataPoint = ifChartThen(index => chart.removeDataPoint(index));
+
+  //  Allow the consumer to export the chart
+  export const exportChart = ifChartThen(() => chart.export());
+
+  /**
+   *  Handle initializing the chart when this Svelte component mounts 
+   */
   onMount(() => {
     chart = new Chart(chartRef, {
       data,

--- a/src/components/base.svelte
+++ b/src/components/base.svelte
@@ -2,7 +2,6 @@
   import { onMount, afterUpdate, onDestroy } from 'svelte';
   import { Chart } from 'frappe-charts/dist/frappe-charts.min.cjs.js';
 
-
   /**
    *  PROPS
    */ 
@@ -30,7 +29,19 @@
       chart.export();
     }
   }
-  
+  //  Allow the consumer to add a data point
+  export function addDataPoint(label, valueFromEachDataset, index) {
+    if (chart) {
+      chart.addDataPoint(label, valueFromEachDataset, index);
+    }
+  }
+  //  Allow the consumer to remove a data point
+  export function removeDataPoint(index) {
+    if (chart) {
+      chart.removeDataPoint(index);
+    }
+  }
+
   /**
    *  COMPONENT
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4513,10 +4513,10 @@ rollup-plugin-node-resolve@^5.2.0:
     resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-svelte@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-svelte/-/rollup-plugin-svelte-6.0.0.tgz#a5b15354371ec17fe67bd4def4d4ea1b915f74cb"
-  integrity sha512-y9qtWa+iNYwXdOZqaEqz3i6k3gzofC9JXzv+WVKDOt0DLiJxJaSrlKKf4YkKG91RzTK5Lo+0fW8in9QH/DxEhA==
+rollup-plugin-svelte@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-svelte/-/rollup-plugin-svelte-6.0.1.tgz#a4fc9c19c5c4277e6dbf8e79185c4cbd6b4383bf"
+  integrity sha512-kS9/JZMBNgpKTqVKlwV8mhmGwxu8NiNf6+n5ZzdZ8yDp3+ADqjf8Au+JNEpoOn6kLlh1hLS2Gsa76k9RP57HDQ==
   dependencies:
     require-relative "^0.8.7"
     rollup-pluginutils "^2.8.2"
@@ -4529,10 +4529,10 @@ rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.26.9:
-  version "2.26.9"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.26.9.tgz#4b6ce4e9044dd257d7314d8ed9b4d4d8a7d166c9"
-  integrity sha512-XIiWYLayLqV+oY4S2Lub/shJq4uk/QQLwWToYCL4LjZbYHbFK3czea4UDVRUJu+zNmKmxq5Zb/OG7c5HSvH2TQ==
+rollup@^2.26.11:
+  version "2.26.11"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.26.11.tgz#4fc31de9c7b83d50916fc8395f8c3d24730cdaae"
+  integrity sha512-xyfxxhsE6hW57xhfL1I+ixH8l2bdoIMaAecdQiWF3N7IgJEMu99JG+daBiSZQjnBpzFxa0/xZm+3pbCdAQehHw==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -4994,10 +4994,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte@^3.24.1:
-  version "3.24.1"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.24.1.tgz#aca364937dd1df27fe131e2a4c234acb6061db4b"
-  integrity sha512-OX/IBVUJSFo1rnznXdwf9rv6LReJ3qQ0PwRjj76vfUWyTfbHbR9OXqJBnUrpjyis2dwYcbT2Zm1DFjOOF1ZbbQ==
+svelte@^3.25.0:
+  version "3.25.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.25.0.tgz#e7f89d11a2223ac02d29f75f82b2a9cca7fd7a54"
+  integrity sha512-CUfq+YTC5Q0tBg7Q9X/QxNutdEYp7ogdbcTZF3mrowOlp3+OF1ZexHwI0Io2VqFSDxht7TlA2lTIQC4RnhR1MQ==
 
 symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Adds support for [modifying data as per `frappe-charts` API](https://frappe.io/charts/docs/reference/api#modifying-data). Specifically, adds:

- `addDataPoint`
- `removeDataPoint`

Also documents the `update` function, which was previously non-obvious.

Closes #19 