### PR TITLE
Update base.svelte

### DIFF
--- a/src/components/base.svelte
+++ b/src/components/base.svelte
@@ -1,6 +1,8 @@
 <script>
   import { onMount, afterUpdate, onDestroy } from 'svelte';
-  import { Chart } from 'frappe-charts/dist/frappe-charts.min.cjs.js';
+  import { Chart } from 'frappe-charts/dist/frappe-charts.esm.js'
+  // import css
+  import 'frappe-charts/dist/frappe-charts.min.css'
 
   /**
    *  PROPS


### PR DESCRIPTION
I reference on https://frappe.io/charts/docs, because with the initial code, I have been getting this error:

`Error: 'Chart' is not exported by node_modules\frappe-charts\dist\frappe-charts.min.cjs.js, imported by node_modules\svelte-frappe-charts\src\components\base.svelte`