### PR TITLE
update frappe-charts import

### DIFF
--- a/src/components/base.svelte
+++ b/src/components/base.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount, afterUpdate, onDestroy } from 'svelte';
-  import { Chart } from 'frappe-charts/dist/frappe-charts.min.cjs.js';
+  import { Chart } from 'frappe-charts';
 
   /**
    *  PROPS


### PR DESCRIPTION
We should let the bundler decide what file to import 🙂 

Current implementation doesn't work with Vite + Svelte + Typescript 👍🏻 