### PR TITLE
 fix #44: Use reactive declaration for data instead of afterUpdate hook

### DIFF
--- a/src/components/base.svelte
+++ b/src/components/base.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount, afterUpdate, onDestroy } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { Chart } from 'frappe-charts';
 
   /**
@@ -55,6 +55,10 @@
   //  Allow the consumer to export the chart
   export const exportChart = ifChartThen(() => chart.export());
 
+  //  Update the chart when incoming data changes
+  const updateChart = ifChartThen((newData) => chart.update(newData));
+  $: updateChart(data);
+
   /**
    *  Handle initializing the chart when this Svelte component mounts
    */
@@ -75,9 +79,6 @@
       maxSlices,
     });
   });
-
-  //  Update the chart when incoming data changes
-  afterUpdate(() => chart.update(data));
 
   //  Mark Chart references for garbage collection when component is unmounted
   onDestroy(() => {


### PR DESCRIPTION
`afterUpdate` hook was causing UncaughtDOMExceptionError.

* Uses reactive declaration to handle changes in data prop instead of `afterUpdate`