### PR TITLE
Adding in showLegend export variable

### DIFF
--- a/src/components/base.svelte
+++ b/src/components/base.svelte
@@ -25,6 +25,7 @@
   export let valuesOverPoints = 0;
   export let isNavigable = false;
   export let maxSlices = 3;
+  export let showLegend = true;
 
   /**
    *  COMPONENT
@@ -76,6 +77,7 @@
       tooltipOptions,
       valuesOverPoints,
       isNavigable,
+	  showLegend,
       maxSlices,
     });
   });


### PR DESCRIPTION
First off - thanks for this library, it's super useful!

I opened a PR for Frappe in relation to using their `showLegend` option - which is fully implemented, but not configurable.

You can find it here: https://github.com/frappe/charts/pull/389

I wanted to add this as a PR on the basis that it gets implemented. I don't think the library will break w/ this if the upstream PR isn't merged, but it would probably be best to only do so when upstream is merged.

Thanks!