### PR TITLE
Update package.json - fix deprecated svelte field

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
   },
   "module": "lib/index.mjs",
   "main": "lib/index.js",
-  "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js",
+    }   
+  },
   "files": [
     "src/",
     "!src/__tests__/**/*",


### PR DESCRIPTION
Using the svelte field in package.json to point at .svelte source files is deprecated and you must use a svelte export condition.